### PR TITLE
Added option to add relations in bulk to existing nodes

### DIFF
--- a/lib/neo4j-bulk.js
+++ b/lib/neo4j-bulk.js
@@ -72,6 +72,23 @@ Bulk.prototype.addRelation = function(startNode, endNode, relationName, data) {
 	});
 };
 
+Bulk.prototype.addRelationByID = function(startNodeID, endNodeID, relationName, data) {
+	var body = {
+		to: '/node/' + endNodeID,
+		type: relationName,
+	};
+
+	if (data !== undefined) {
+		body.data = data;
+	}
+
+	this._relations.push({
+		method: 'POST',
+		to: '/node/' + startNodeID + '/relationships',
+		body: body,
+	});
+};
+
 Bulk.prototype.branch = function() {
 	var branch = new Bulk();
 	branch._nodes = this._nodes.slice(0);


### PR DESCRIPTION
I'm often using  my Neo4J bulk importers in 2 passes. One to add all the nodes and one to add all the relations. My batches are so large I can't keep them in memory to rely on ids from just one batch run and keeping an index for millions of nodes is also not always an option.

I amended your module with a method to create relation items in batch with existing nodes (ids). Figured it might be of use for someone else in the future so I created this pull request.

Thanks for creating your module and making it available on npm.
